### PR TITLE
php:8.1-apache で docker build すると python2.7のインストールにコケる問題の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update \
         git-core \
         build-essential \
         openssl \
-        python2.7 \
+        python3 \
         zip \
         unzip \
     && docker-php-ext-configure gd --with-jpeg \
@@ -37,7 +37,7 @@ RUN apt-get update \
     && docker-php-ext-enable imagick \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable redis \
-    && ln -s /usr/bin/python2.7 /usr/bin/python \
+    && ln -s /usr/bin/python3 /usr/bin/python \
     && a2enmod headers \
     && a2enmod mime \
     && a2enmod expires \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     && docker-php-ext-install pdo_mysql \
     && docker-php-ext-install mysqli \
     && docker-php-ext-install opcache \
+    && docker-php-ext-install bcmath \
     && docker-php-ext-enable mysqli \
     && pecl install imagick \
         apcu \


### PR DESCRIPTION
php:8.1-apache で docker build すると python2.7のインストールにコケる問題を修正するためインストールする python のバージョンを3にアップデートしました。

エラー内容は以下になります。

```
2.461 E: Unable to locate package python2.7
2.461 E: Couldn't find any package by glob 'python2.7'
2.461 E: Couldn't find any package by regex 'python2.7'
```

また、GoogleAnalytics4拡張アプリのデバックに不便だったので、bcmathを追加しています。