### PR TITLE
php8.3対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 
 # extension
 RUN apt-get update \
@@ -32,10 +32,8 @@ RUN apt-get update \
     && docker-php-ext-install opcache \
     && docker-php-ext-install bcmath \
     && docker-php-ext-enable mysqli \
-    && pecl install imagick \
-        apcu \
+    && pecl install apcu \
         redis \
-    && docker-php-ext-enable imagick \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable redis \
     && ln -s /usr/bin/python3 /usr/bin/python \


### PR DESCRIPTION
PHP8.3対応のDockerfileを作成しました。

注意点として、 php8.3 で imagickの不具合により、pecl経由でのインストールできないため、imagick はインストールしないようにしました。

ただ、↓ の内容によると近いうちに修正バージョンがリリースされるようなのでリリースされたら対応が必要かと思います。
https://github.com/Imagick/imagick/pull/641