### PR TITLE
php8.3 xdebug対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.2-apache
+FROM php:8.3-apache
 
 # extension
 RUN apt-get update \
@@ -32,11 +32,9 @@ RUN apt-get update \
     && docker-php-ext-install opcache \
     && docker-php-ext-install bcmath \
     && docker-php-ext-enable mysqli \
-    && pecl install imagick \
-        apcu \
+    && pecl install apcu \
         redis \
         xdebug \
-    && docker-php-ext-enable imagick \
     && docker-php-ext-enable apcu \
     && docker-php-ext-enable redis \
     && docker-php-ext-enable xdebug \


### PR DESCRIPTION
xdebug版のPHP8.3用Dockerfileです。

[php 8.3対応](#3)と同様に、imagickは外してあります。