### PR TITLE
pr-cleanup.yml のパッケージ名解決とエラーハンドリングを修正

### DIFF
--- a/.github/workflows/pr-cleanup.yml
+++ b/.github/workflows/pr-cleanup.yml
@@ -21,7 +21,10 @@ jobs:
       contents: read
     env:
       PR_NUMBER: ${{ github.event.number }}
-      PACKAGE_NAME: acms-dev
+      # GHCR のパッケージ名は ghcr.io/<owner>/ の後ろのパス全体
+      # （リポジトリ名/イメージ名）になる。単なるイメージ名（acms-dev）だけでは
+      # 存在しないパッケージとして 404 になるため注意。
+      PACKAGE_NAME: ${{ github.event.repository.name }}/acms-dev
       OWNER: ${{ github.repository_owner }}
 
     steps:
@@ -33,7 +36,7 @@ jobs:
             echo "has_token=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_token=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GHCR_DELETE_TOKEN が未設定のため、PR プレビューイメージの自動削除をスキップしました。ghcr.io/${OWNER}/<repo>/${PACKAGE_NAME} の '-${PR_NUMBER}' サフィックスのタグは手動削除するか、delete:packages 権限を持つ PAT を GHCR_DELETE_TOKEN に設定してください。"
+            echo "::warning::GHCR_DELETE_TOKEN が未設定のため、PR プレビューイメージの自動削除をスキップしました。ghcr.io/${OWNER}/${PACKAGE_NAME} の '-${PR_NUMBER}' サフィックスのタグは手動削除するか、delete:packages 権限を持つ PAT を GHCR_DELETE_TOKEN に設定してください。"
           fi
 
       - name: Delete preview versions
@@ -42,11 +45,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GHCR_DELETE_TOKEN }}
         run: |
-          set -euo pipefail
+          set -uo pipefail
           suffix="-${PR_NUMBER}"
+          # パッケージ名に含まれる "/" は API パスでは %2F にエンコードする
+          encoded_name="$(printf '%s' "$PACKAGE_NAME" | sed 's|/|%2F|g')"
           echo "Package ${PACKAGE_NAME} のバージョンから suffix '${suffix}' を検索します..."
 
-          ids="$(gh api --paginate "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions" \
+          raw="$(gh api --paginate "/orgs/${OWNER}/packages/container/${encoded_name}/versions" 2>&1)"
+          rc=$?
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::GHCR パッケージ '${PACKAGE_NAME}' のバージョン取得に失敗しました（存在しない/非公開/権限不足のいずれかの可能性）。削除はスキップします。詳細: ${raw}"
+            exit 0
+          fi
+
+          ids="$(printf '%s' "$raw" \
             | jq -s 'add' \
             | jq -r --arg suffix "$suffix" \
                 '.[] | select((.metadata.container.tags // []) | any(endswith($suffix))) | .id')"
@@ -58,5 +70,5 @@ jobs:
 
           echo "$ids" | while read -r id; do
             echo "Deleting version id=${id}"
-            gh api --method DELETE "/orgs/${OWNER}/packages/container/${PACKAGE_NAME}/versions/${id}"
+            gh api --method DELETE "/orgs/${OWNER}/packages/container/${encoded_name}/versions/${id}"
           done


### PR DESCRIPTION
## 問題

PR #9 のマージ時に `pr-cleanup.yml` が失敗した。

```
Package acms-dev のバージョンから suffix '-9' を検索します...
gh: Package not found. (HTTP 404)
jq: error (at <stdin>:5): Cannot index string with string "metadata"
Error: Process completed with exit code 5.
```

## 原因

1. **パッケージ名の誤り**：GHCR にプッシュしているのは `ghcr.io/<owner>/acms-development-docker-images/acms-dev` なので、GHCR 上のパッケージ名は `acms-dev` 単体ではなく `acms-development-docker-images/acms-dev`（リポジトリ名込みのパス）。匿名レジストリAPIで実在パスを確認して特定した。
2. **エラーハンドリング不足**：`gh api` が 404 のエラー本文（JSON オブジェクト）をそのまま jq に渡していたため、`.[]` がオブジェクトの値（文字列）を返し、`.metadata` アクセスで意味不明なクラッシュになっていた。

## 修正内容

- `PACKAGE_NAME` を `${{ github.event.repository.name }}/acms-dev` に変更（リポジトリ改名にも自動追従）
- パッケージ名の `/` を API パスで `%2F` にエンコード
- `gh api` の exit code を明示チェックし、失敗時は `::warning::` を出して安全にスキップ（jq クラッシュを防止）

## 検証

- `actionlint` 通過
- 匿名 GHCR レジストリAPI で `appleple/acms-development-docker-images/acms-dev` が実在パス（`UNAUTHORIZED` = 存在するが非公開）であることを確認。`appleple/acms-dev` 単体は `NAME_UNKNOWN`（存在しない）だったことも確認済み

## 補足（別途要確認）

GHCR パッケージが private の可能性が高い（GitHub の既定挙動）。PR プレビューを外部レビュアーが `docker pull` できる想定なら、Package の Visibility を Public に変更する必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)