### PR TITLE
Dependabot の patch/minor 更新を自動マージするワークフローを追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+# Dependabot が作成した PR のうち、patch/minor 更新は自動マージする。
+# major 更新は互換性への影響が大きいため対象外とし、人手でレビューする。
+# 前提: リポジトリ設定で "Allow auto-merge" を有効化していること。
+# ブランチ保護で必須ステータスチェックを設定していない場合、CI 完了を待たずに
+# マージされる点に注意。
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions: {}
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch/minor updates
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for patch/minor updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        shell: bash
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
major 更新は互換性確認のため引き続き人手レビューとし、patch/minor のみ
gh pr merge --auto で自動化することでレビュー負荷を下げる。